### PR TITLE
feat(utils): add MinInt function for comparing integers

### DIFF
--- a/internal/adminpanel/panel.go
+++ b/internal/adminpanel/panel.go
@@ -27,7 +27,7 @@ func (ap *AdminPanel) GetLogEntries(ctx interface{}, maxCount uint) []*logging.L
 	if err != nil {
 		return []*logging.LogEntry{}
 	}
-	entries = entries[:min(uint(len(entries)), maxCount)]
+	entries = entries[:utils.MinInt(len(entries), int(maxCount))]
 	permissibleEntries := make([]*logging.LogEntry, 0)
 	for _, entry := range entries {
 		allowed, err := ap.PermissionChecker.HasLogViewPermission(ctx, entry.ID)

--- a/internal/utils/checks.go
+++ b/internal/utils/checks.go
@@ -1,0 +1,8 @@
+package utils
+
+func MinInt(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}


### PR DESCRIPTION
Introduce a utility function MinInt to determine the minimum of two integers. This enhances code readability and reusability by abstracting common logic. Updated admin panel to use MinInt for slicing log entries, improving clarity and maintainability.