### PR TITLE
fix(workflow): update path for complexity check in workflow

### DIFF
--- a/.github/workflows/complecity-check.yml
+++ b/.github/workflows/complecity-check.yml
@@ -21,7 +21,7 @@ jobs:
         run: go install github.com/fzipp/gocyclo/cmd/gocyclo@latest
 
       - name: Run gocyclo
-        run: gocyclo -over 20 ./... || exit 1
+        run: gocyclo -over 20 . || exit 1
 
       - name: Fail on high complexity
         if: failure()


### PR DESCRIPTION
This change refines the path for the gocyclo complexity check to run in the current directory instead of all subdirectories. This adjustment aims to make the complexity analysis more focused and potentially reduce unnecessary checks, enhancing workflow efficiency.